### PR TITLE
fix: TypeError: reduce() of empty iterable with no initial value

### DIFF
--- a/scripts/yosys2compress.py
+++ b/scripts/yosys2compress.py
@@ -311,9 +311,9 @@ def add_ports_definition(lines, ports_cfg):
         if c in ports_cfg["inputs"]:
             del ports_cfg["inputs"][c]
     # Second create the lines
-    inputs_str_port_sigs = ft.reduce(lambda a, b: a+' '+b, ports_cfg["inputs"].keys())
-    outputs_str_port_sigs = ft.reduce(lambda a, b: a+' '+b, ports_cfg["outputs"].keys())
-    controls_str_port_sigs = ft.reduce(lambda a, b: a+' '+b, ports_cfg["controls"].keys())
+    inputs_str_port_sigs = ft.reduce(lambda a, b: a+' '+b, ports_cfg["inputs"].keys(), "").strip()
+    outputs_str_port_sigs = ft.reduce(lambda a, b: a+' '+b, ports_cfg["outputs"].keys(), "").strip()
+    controls_str_port_sigs = ft.reduce(lambda a, b: a+' '+b, ports_cfg["controls"].keys(), "").strip()
     lines.insert(0, "INPUTS {}".format(inputs_str_port_sigs)) 
     lines.insert(1, "OUTPUTS {}".format(outputs_str_port_sigs)) 
     lines.insert(2, "CONTROLS {}".format(controls_str_port_sigs)) 


### PR DESCRIPTION
Hey there,
I am unsure if this is only an issue on my end but I am encountering the following error:

```sh
Traceback (most recent call last):
  File ".../compress/scripts/yosys2compress.py", line 356, in <module>
    add_ports_definition(circuit_compress_lines, dic_ports)
  File ".../compress/scripts/yosys2compress.py", line 319, in add_ports_definition
    controls_str_port_sigs = ft.reduce(lambda a, b: a+' '+b, ports_cfg["controls"].keys())
TypeError: reduce() of empty iterable with no initial value
```

The line in question is
```py
controls_str_port_sigs = ft.reduce(lambda a, b: a+' '+b, ports_cfg["controls"].keys())
```

When processing the `canright_aes_sbox_opt` make script from the artifact of your paper, it seems like this dictionary stays empty for me (I dont know if this is supposed to happen?)

Therefore I am proposing this change to fix the error and handle possibly empty dictionaries.
Have a nice day ^^